### PR TITLE
Add unix_timestamp_unit option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ TODO: Write short description here
 - **table**: table name (string, required)
 - **session**: bulk_import session name (string, optional)
 - **time_column**: user-defined time column (string, optional)
+- **unix_timestamp_unit**: if type of "time" or **time_column** is long, it's considered unix timestamp. This option specify its unit in sec, milli, micro or nano (enum, default: `sec`)
 - **tmpdir**: temporal directory
 - **upload_concurrency**: upload concurrency (int, default=2). max concurrency is 8.
 - **file_split_size**: split size (long, default=16384 (16MB)).

--- a/src/main/java/org/embulk/output/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/TdOutputPlugin.java
@@ -7,6 +7,8 @@ import javax.validation.constraints.Max;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.treasuredata.api.TdApiClient;
 import com.treasuredata.api.TdApiClientConfig;
 import com.treasuredata.api.TdApiClientConfig.HttpProxyConfig;
@@ -78,6 +80,10 @@ public class TdOutputPlugin
         @ConfigDefault("null")
         public Optional<String> getTimeColumn();
 
+        @Config("unix_timestamp_unit")
+        @ConfigDefault("\"sec\"")
+        public UnixTimestampUnit getUnixTimestampUnit();
+
         @Config("tmpdir")
         @ConfigDefault("\"/tmp\"")
         public String getTempDir();
@@ -114,6 +120,47 @@ public class TdOutputPlugin
         @Config("use_ssl")
         @ConfigDefault("false")
         public boolean getUseSsl();
+    }
+
+    public static enum UnixTimestampUnit
+    {
+        SEC(1),
+        MILLI(1000),
+        MICRO(1000000),
+        NANO(1000000000);
+
+        private final int unit;
+
+        private UnixTimestampUnit(int unit)
+        {
+            this.unit = unit;
+        }
+
+        public int getFractionUnit()
+        {
+            return unit;
+        }
+
+        @JsonCreator
+        public static UnixTimestampUnit of(String s)
+        {
+            switch (s) {
+            case "sec": return SEC;
+            case "milli": return MILLI;
+            case "micro": return MICRO;
+            case "nano": return NANO;
+            default:
+                throw new ConfigException(
+                        String.format("Unknown unix_timestamp_unit '%s'. Supported units are sec, milli, micro, and nano"));
+            }
+        }
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return name().toLowerCase();
+        }
     }
 
     private final Logger log;


### PR DESCRIPTION
In my data format (TSV), created_at column is stored as unix timestamp
in nanoseconds. Because Treasure Data expects seconds, something needs
to convert it. It is useful if td output supports this conversion.
This pull-request adds `unix_timestamp_unit` to support this conversion.