### PR TITLE
Changes a field writer for 'time' column that is timestamp typed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,16 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile     "org.embulk:embulk-core:0.6.19"
-    provided    "org.embulk:embulk-core:0.6.19"
-    compile     "org.embulk:embulk-standards:0.6.19"
-    provided    "org.embulk:embulk-standards:0.6.19"
+    compile     "org.embulk:embulk-core:0.6.25"
+    provided    "org.embulk:embulk-core:0.6.25"
+    compile     "org.embulk:embulk-standards:0.6.25"
+    provided    "org.embulk:embulk-standards:0.6.25"
     compile     "org.eclipse.jetty:jetty-client:9.2.2.v20140723"
     compile     "org.msgpack:msgpack:0.6.11"
 
     testCompile "junit:junit:4.+"
     testCompile "org.bigtesting:fixd:1.0.0"
+    testCompile  "org.embulk:embulk-core:0.6.25:tests"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {

--- a/src/main/java/org/embulk/output/td/RecordWriter.java
+++ b/src/main/java/org/embulk/output/td/RecordWriter.java
@@ -317,7 +317,8 @@ public class RecordWriter
                             writer = new UnixTimestampLongFieldWriter(columnName, task.getUnixTimestampUnit().getFractionUnit());
                             hasPkWriter = true;
                         } else if (columnType instanceof TimestampType) {
-                            writer = new TimestampStringFieldWriter(timestampFormatters[i], columnName);
+                            writer = new TimestampLongFieldWriter(columnName);
+
                             hasPkWriter = true;
                         } else {
                             throw new ConfigException(String.format("Type of '%s' column must be long or timestamp but got %s",

--- a/src/test/java/org/embulk/output/td/TestFieldWriter.java
+++ b/src/test/java/org/embulk/output/td/TestFieldWriter.java
@@ -1,0 +1,105 @@
+package org.embulk.output.td;
+
+import com.google.common.collect.ImmutableList;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigLoader;
+import org.embulk.config.ConfigSource;
+import org.embulk.output.td.RecordWriter.FieldWriterSet;
+import org.embulk.spi.Column;
+import org.embulk.spi.ColumnConfig;
+import org.embulk.spi.Exec;
+import org.embulk.spi.Schema;
+import org.embulk.spi.SchemaConfig;
+import org.embulk.spi.type.Type;
+import org.embulk.spi.type.Types;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestFieldWriter
+{
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    private Logger log;
+
+    @Before
+    public void createLogger()
+    {
+        log = Exec.getLogger(TestFieldWriter.class);
+    }
+
+    private ConfigSource config()
+    {
+        return new ConfigLoader(runtime.getModelManager()).newConfigSource();
+    }
+
+    private Schema schema(Column... columns)
+    {
+        ImmutableList.Builder<Column> builder = new ImmutableList.Builder<Column>();
+        for (Column col : columns) {
+            builder.add(col);
+        }
+        return new Schema(builder.build());
+    }
+
+    private Column column(int index, String name, Type type)
+    {
+        return new Column(index, name, type);
+    }
+
+    private TdOutputPlugin.PluginTask task(ConfigSource outConfig)
+    {
+        return outConfig.loadConfig(TdOutputPlugin.PluginTask.class);
+    }
+
+    @Test
+    public void test()
+    {
+        { // time column exists
+            // out: config
+            ConfigSource outConfig = config()
+                    .set("apikey", "xxx")
+                    .set("database", "mydb")
+                    .set("table", "mytbl");
+
+            // schema
+            Schema schema = schema(
+                    column(0, "time", Types.TIMESTAMP),
+                    column(1, "c1", Types.TIMESTAMP));
+
+            // create field writers
+            FieldWriterSet writers = new FieldWriterSet(log, task(outConfig), schema);
+
+            assertEquals(schema.getColumnCount(), writers.getFieldCount());
+            assertTrue(writers.getFieldWriter(0) instanceof RecordWriter.TimestampLongFieldWriter);
+            assertTrue(writers.getFieldWriter(1) instanceof RecordWriter.TimestampStringFieldWriter);
+        }
+
+        { // time column doesn't exists. users need to specify another column as time column
+            // out: config
+            ConfigSource outConfig = config()
+                    .set("apikey", "xxx")
+                    .set("database", "mydb")
+                    .set("table", "mytbl")
+                    .set("time_column", "c1");
+            TdOutputPlugin.PluginTask task = outConfig.loadConfig(TdOutputPlugin.PluginTask.class);
+
+            // schema
+            Schema schema = schema(
+                    column(0, "c0", Types.TIMESTAMP),
+                    column(1, "c1", Types.TIMESTAMP));
+
+            // create field writers
+            FieldWriterSet writers = new FieldWriterSet(log, task(outConfig), schema);
+
+            assertEquals(schema.getColumnCount() + 1, writers.getFieldCount());
+            assertTrue(writers.getFieldWriter(0) instanceof RecordWriter.TimestampStringFieldWriter);
+            assertTrue(writers.getFieldWriter(1) instanceof RecordWriter.TimestampFieldLongDuplicator);
+        }
+    }
+}


### PR DESCRIPTION
Changed TimestampStringFieldWriter to TimestampLongFieldWriter. Because bulk_import_perform requires long type as 'time' column type.