### PR TITLE
Add mode to time value option

### DIFF
--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -213,19 +213,6 @@ public class TdOutputPlugin
         public boolean getUseSsl();
     }
 
-    public interface TimeValueConfig
-            extends Task
-    {
-        @Config("from")
-        @Min(0)
-        public long getFrom();
-
-        @Config("to")
-        @ConfigDefault("0")
-        @Min(0)
-        public long getTo();
-    }
-
     public static enum ConvertTimestampType
     {
         STRING(-1),

--- a/src/main/java/org/embulk/output/td/TimeValueConfig.java
+++ b/src/main/java/org/embulk/output/td/TimeValueConfig.java
@@ -1,0 +1,35 @@
+package org.embulk.output.td;
+
+import com.google.common.base.Optional;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.Task;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+public interface TimeValueConfig
+        extends Task
+{
+    @Config("mode")
+    @ConfigDefault("\"incremental_time\"")
+    String getMode();
+
+    @Config("value")
+    @ConfigDefault("null")
+    @Min(0)
+    @Max(253402300799L) // '9999-12-31 23:59:59 UTC'
+    Optional<Long> getValue();
+
+    @Config("from")
+    @ConfigDefault("null")
+    @Min(0)
+    @Max(253402300799L) // '9999-12-31 23:59:59 UTC'
+    Optional<Long> getFrom();
+
+    @Config("to")
+    @ConfigDefault("null")
+    @Min(0)
+    @Max(253402300799L) // '9999-12-31 23:59:59 UTC'
+    Optional<Long> getTo();
+}

--- a/src/main/java/org/embulk/output/td/TimeValueGenerator.java
+++ b/src/main/java/org/embulk/output/td/TimeValueGenerator.java
@@ -1,0 +1,79 @@
+package org.embulk.output.td;
+
+import com.google.common.base.Optional;
+import org.embulk.config.ConfigException;
+
+public abstract class TimeValueGenerator
+{
+    public abstract long next();
+
+    public static TimeValueGenerator newGenerator(final TimeValueConfig config)
+    {
+        switch (config.getMode()) {
+            case "incremental_time": { // default mode
+                require(config.getFrom(), "'from', 'to'");
+                require(config.getTo(), "'to'");
+                reject(config.getValue(), "'value'");
+
+                return new TimeValueGenerator()
+                {
+                    private final long from = config.getFrom().get();
+                    private final long to = config.getTo().get();
+
+                    private long current = from;
+
+                    @Override
+                    public long next()
+                    {
+                        try {
+                            return current++;
+                        }
+                        finally {
+                            if (current > to) {
+                                current = from;
+                            }
+                        }
+                    }
+                };
+            }
+            case "fixed_time": {
+                require(config.getValue(), "'value'");
+                reject(config.getFrom(), "'from'");
+                reject(config.getTo(), "'to'");
+
+                return new TimeValueGenerator()
+                {
+                    private final long fixed = config.getValue().get();
+
+                    @Override
+                    public long next()
+                    {
+                        return fixed;
+                    }
+                };
+            }
+            default: {
+                throw new ConfigException(String.format("Unknwon mode '%s'. Supported methods are incremental_time, fixed_time.", config.getMode()));
+            }
+        }
+    }
+
+    // ported from embulk-input-s3
+    private static <T> T require(Optional<T> value, String message)
+    {
+        if (value.isPresent()) {
+            return value.get();
+        }
+        else {
+            throw new ConfigException("Required option is not set: " + message);
+        }
+    }
+
+    // ported from embulk-input-s3
+    private static <T> void reject(Optional<T> value, String message)
+    {
+        if (value.isPresent()) {
+            throw new ConfigException("Invalid option is set: " + message);
+        }
+    }
+}

--- a/src/main/java/org/embulk/output/td/writer/FieldWriterSet.java
+++ b/src/main/java/org/embulk/output/td/writer/FieldWriterSet.java
@@ -7,6 +7,8 @@ import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.embulk.config.ConfigException;
 import org.embulk.output.td.TdOutputPlugin;
+import org.embulk.output.td.TimeValueConfig;
+import org.embulk.output.td.TimeValueGenerator;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.PageReader;
@@ -20,7 +22,6 @@ import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.util.Timestamps;
 import org.embulk.output.td.MsgpackGZFileBuilder;
-import org.embulk.output.td.TdOutputPlugin.TimeValueConfig;
 import org.slf4j.Logger;
 
 public class FieldWriterSet
@@ -220,7 +221,7 @@ public class FieldWriterSet
         }
 
         if (timeValueConfig.isPresent()) {
-            staticTimeValue = Optional.of(new TimeValueGenerator(timeValueConfig.get()));
+            staticTimeValue = Optional.of(TimeValueGenerator.newGenerator(timeValueConfig.get()));
         }
         else {
             staticTimeValue = Optional.absent();
@@ -319,31 +320,6 @@ public class FieldWriterSet
         }
         catch (IOException e) {
             throw Throwables.propagate(e);
-        }
-    }
-
-    static class TimeValueGenerator
-    {
-        private final long from;
-        private final long to;
-        private long current;
-
-        TimeValueGenerator(TimeValueConfig config)
-        {
-            current = from = config.getFrom();
-            to = config.getTo();
-        }
-
-        long next()
-        {
-            try {
-                return current++;
-            }
-            finally {
-                if (current >= to) {
-                    current = from;
-                }
-            }
         }
     }
 }

--- a/src/test/java/org/embulk/output/td/TestTimeValueGenerator.java
+++ b/src/test/java/org/embulk/output/td/TestTimeValueGenerator.java
@@ -1,0 +1,125 @@
+package org.embulk.output.td;
+
+import com.google.common.collect.ImmutableMap;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigException;
+import org.embulk.config.ConfigSource;
+import org.embulk.output.td.writer.FieldWriterSet;
+import org.embulk.spi.Exec;
+import org.embulk.spi.Schema;
+import org.embulk.spi.type.Types;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import static org.embulk.output.td.TestTdOutputPlugin.config;
+import static org.embulk.output.td.TestTdOutputPlugin.pluginTask;
+import static org.embulk.output.td.TestTdOutputPlugin.schema;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestTimeValueGenerator
+{
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    private Logger log;
+    private ConfigSource config;
+    private Schema schema;
+
+    @Before
+    public void createResources()
+    {
+        log = Exec.getLogger(TestTimeValueGenerator.class);
+        config = config();
+    }
+
+    @Test
+    public void validateTimeValue()
+    {
+        // incremental_time
+        { // {from: 0, to: 0} # default incremental_time
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("from", 0L, "to", 0L))), schema);
+        }
+        { // {from: 0} # default incremental_time
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            try {
+                new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("from", 0L))), schema);
+                fail();
+            }
+            catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+        { // {to: 0} # default incremental_time
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            try {
+                new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("to", 0L))), schema);
+                fail();
+            }
+            catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+        { // {from: 0, to: 0, mode: incremental_time}
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("from", 0L, "to", 0L, "mode", "incremental_time"))), schema);
+        }
+        { // {from: 0, mode: incremental_time}
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            try {
+                new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("from", 0L, "mode", "incremental_time"))), schema);
+                fail();
+            }
+            catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+        { // {to: 0, mode: incremental_time}
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            try {
+                new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("to", 0L, "mode", "incremental_time"))), schema);
+                fail();
+            }
+            catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+        { // {mode: incremental_time}
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            try {
+                new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("mode", "incremental_time"))), schema);
+                fail();
+            }
+            catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+
+        // fixed_time
+        { // {value: 0, mode: fixed_time}
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("value", 0L, "mode", "fixed_time"))), schema);
+        }
+        { // {mode: fixed_time}
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            try {
+                new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("mode", "fixed_time"))), schema);
+            }
+            catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+        { // {value: 0}
+            schema = schema("_c0", Types.STRING, "_c1", Types.LONG);
+            try {
+                new FieldWriterSet(log, pluginTask(config.set("time_value", ImmutableMap.of("value", 0L))), schema);
+            }
+            catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+    }
+}


### PR DESCRIPTION
if a user wants to manually specify a single fixed time
```
time_value: {value: 1000, mode: fixed_time}
```

if a user wants to manually specify an incremental time (default behavior if not mode specified)
```
time_value: {from: 0, to: 1000}
time_value: {from: 0, to: 1000, mode: incremental_time}
```