### PR TITLE
Get temporary directory path from System.property('java.io.tmpdir')

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ TODO: Write short description here
 - **session**: bulk_import session name (string, optional)
 - **time_column**: user-defined time column (string, optional)
 - **unix_timestamp_unit**: if type of "time" or **time_column** is long, it's considered unix timestamp. This option specify its unit in sec, milli, micro or nano (enum, default: `sec`)
-- **tmpdir**: temporal directory
+- **tmpdir**: temporal directory (string, optional) if set to null, plugin will use directory that could get from System.property
 - **upload_concurrency**: upload concurrency (int, default=2). max concurrency is 8.
 - **file_split_size**: split size (long, default=16384 (16MB)).
 - **stop_on_invalid_record**: stop bulk load transaction if a file includes invalid record (such as invalid timestamp) (boolean, default=false).

--- a/src/main/java/org/embulk/output/td/RecordWriter.java
+++ b/src/main/java/org/embulk/output/td/RecordWriter.java
@@ -50,7 +50,7 @@ public class RecordWriter
         this.taskIndex = taskIndex;
 
         this.fieldWriters = fieldWriters;
-        this.tempDir = new File(task.getTempDir());
+        this.tempDir = new File(task.getTempDir().get());
         this.executor = new FinalizableExecutorService();
         this.uploadConcurrency = task.getUploadConcurrency();
         this.fileSplitSize = task.getFileSplitSize() * 1024;

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -1,5 +1,6 @@
 package org.embulk.output.td;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -118,8 +119,9 @@ public class TdOutputPlugin
         public UnixTimestampUnit getUnixTimestampUnit();
 
         @Config("tmpdir")
-        @ConfigDefault("\"/tmp\"")
-        public String getTempDir();
+        @ConfigDefault("null")
+        public Optional<String> getTempDir();
+        public void setTempDir(String dir);
 
         @Config("upload_concurrency")
         @ConfigDefault("2")
@@ -323,6 +325,10 @@ public class TdOutputPlugin
 
         // generate session name
         task.setSessionName(buildBulkImportSessionName(task, Exec.session()));
+
+        if (!task.getTempDir().isPresent()) {
+            task.setTempDir(getEnvironmentTempDirectory());
+        }
 
         try (TDClient client = newTDClient(task)) {
             String databaseName = task.getDatabase();
@@ -797,5 +803,11 @@ public class TdOutputPlugin
                 closeLater.close();
             }
         }
+    }
+
+    @VisibleForTesting
+    String getEnvironmentTempDirectory()
+    {
+        return System.getProperty("java.io.tmpdir");
     }
 }

--- a/src/test/java/org/embulk/output/td/TestRecordWriter.java
+++ b/src/test/java/org/embulk/output/td/TestRecordWriter.java
@@ -57,7 +57,7 @@ public class TestRecordWriter
                 "_c2", Types.BOOLEAN, "_c3", Types.DOUBLE, "_c4", Types.TIMESTAMP);
 
         plugin = plugin();
-        task = pluginTask(config().set("session_name", "my_session"));
+        task = pluginTask(config().set("session_name", "my_session").set("tmpdir", plugin.getEnvironmentTempDirectory()));
     }
 
     @Test
@@ -192,7 +192,11 @@ public class TestRecordWriter
     {
         schema = schema("_c0", Types.LONG, "_c1", Types.STRING,
                 "_c2", Types.BOOLEAN, "_c3", Types.DOUBLE, "_c4", Types.TIMESTAMP);
-        task = pluginTask(config().set("session_name", "my_session").set("time_value", ImmutableMap.of("from", 0L, "to", 0L)));
+        task = pluginTask(config()
+                .set("session_name", "my_session")
+                .set("time_value", ImmutableMap.of("from", 0L, "to", 0L))
+                .set("tmpdir", plugin.getEnvironmentTempDirectory())
+        );
         recordWriter = recordWriter(task, tdClient(plugin, task), fieldWriters(log, task, schema));
 
         try {

--- a/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
+++ b/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
@@ -473,6 +473,7 @@ public class TestTdOutputPlugin
         task.setSessionName("session_name");
         task.setLoadTargetTableName("my_table");
         task.setDoUpload(true);
+        task.setTempDir(plugin.getEnvironmentTempDirectory());
         Schema schema = schema("time", Types.LONG, "c0", Types.STRING, "c1", Types.STRING);
 
         try (TransactionalPageOutput output = plugin.open(task.dump(), schema, 0)) {


### PR DESCRIPTION
Current version get temporary directory path from `@ConfigDefault("\"/tmp\"")`.
This code causes IOException at Windows environment because /tmp doesn't exists at Windows FileSystem.

I changed code so that plugin get temporary directory path from `System.property('java.io.tmpdir')`.

I confirmed this change works file at following environments.
* Windows 10
* Mac OS X El Capitan
* Linux(Amazon Linux AMI 2015.09)