### PR TITLE
Make |FieldWriterSet| to be created always from |TdOutputPlugin.PluginTask|.

### DIFF
--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -870,19 +870,13 @@ public class TdOutputPlugin
         return System.getProperty("java.io.tmpdir");
     }
 
-    protected FieldWriterSet createFieldWriterSet(Logger log, Task task, Schema schema)
+    protected FieldWriterSet createFieldWriterSet(Logger log, PluginTask task, Schema schema)
     {
-        if (!(task instanceof PluginTask)) {
-            throw new RuntimeException("Fatal unexpected error: Task for FieldWriterSet is not TdOutputPlugin.PluginTask.");
-        }
-        return FieldWriterSet.createWithValidation(log, (PluginTask) task, schema, true);
+        return FieldWriterSet.createWithValidation(log, task, schema, true);
     }
 
-    protected void validateFieldWriterSet(Logger log, Task task, Schema schema)
+    protected void validateFieldWriterSet(Logger log, PluginTask task, Schema schema)
     {
-        if (!(task instanceof PluginTask)) {
-            throw new RuntimeException("Fatal unexpected error: Task for FieldWriterSet is not TdOutputPlugin.PluginTask.");
-        }
-        FieldWriterSet.createWithValidation(log, (PluginTask) task, schema, false);
+        FieldWriterSet.createWithValidation(log, task, schema, false);
     }
 }


### PR DESCRIPTION
@muga Sorry, I had a mistake in the previous change. The helper methods to create `FieldWriterSet` don't need to care about `Task` other than `TdOutputPlugin.PluginTask`. They are always called from `TdOutputPlugin` with its `PluginTask`.