### PR TITLE
Change variable's type of PluginTask.setTempDir() to Optional<String>

### DIFF
--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -124,7 +124,7 @@ public class TdOutputPlugin
         @Config("tmpdir")
         @ConfigDefault("null")
         public Optional<String> getTempDir();
-        public void setTempDir(String dir);
+        public void setTempDir(Optional<String> dir);
 
         @Config("upload_concurrency")
         @ConfigDefault("2")
@@ -350,7 +350,7 @@ public class TdOutputPlugin
         task.setSessionName(buildBulkImportSessionName(task, Exec.session()));
 
         if (!task.getTempDir().isPresent()) {
-            task.setTempDir(getEnvironmentTempDirectory());
+            task.setTempDir(Optional.of(getEnvironmentTempDirectory()));
         }
 
         try (TDClient client = newTDClient(task)) {

--- a/src/test/java/org/embulk/output/td/TestRecordWriter.java
+++ b/src/test/java/org/embulk/output/td/TestRecordWriter.java
@@ -1,5 +1,6 @@
 package org.embulk.output.td;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.treasuredata.client.TDClient;
 import org.embulk.EmbulkTestRuntime;
@@ -57,7 +58,8 @@ public class TestRecordWriter
                 "_c2", Types.BOOLEAN, "_c3", Types.DOUBLE, "_c4", Types.TIMESTAMP);
 
         plugin = plugin();
-        task = pluginTask(config().set("session_name", "my_session").set("tmpdir", plugin.getEnvironmentTempDirectory()));
+        task = pluginTask(config().set("session_name", "my_session")
+                .set("tmpdir", Optional.of(plugin.getEnvironmentTempDirectory())));
     }
 
     @Test
@@ -195,7 +197,7 @@ public class TestRecordWriter
         task = pluginTask(config()
                 .set("session_name", "my_session")
                 .set("time_value", ImmutableMap.of("from", 0L, "to", 0L))
-                .set("tmpdir", plugin.getEnvironmentTempDirectory())
+                .set("tmpdir", Optional.of(plugin.getEnvironmentTempDirectory()))
         );
         recordWriter = recordWriter(task, tdClient(plugin, task), fieldWriters(log, task, schema));
 

--- a/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
+++ b/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
@@ -545,7 +545,7 @@ public class TestTdOutputPlugin
         task.setSessionName("session_name");
         task.setLoadTargetTableName("my_table");
         task.setDoUpload(true);
-        task.setTempDir(plugin.getEnvironmentTempDirectory());
+        task.setTempDir(Optional.of(plugin.getEnvironmentTempDirectory()));
         Schema schema = schema("time", Types.LONG, "c0", Types.STRING, "c1", Types.STRING);
 
         TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);


### PR DESCRIPTION
In current implementation `getTempDir()` at PluginTask returns `Optional<String>`.
But `setTempDir()` accepts `String`.

This differences was made at #39.