### PR TITLE
Not submit performjob if no parts

### DIFF
--- a/src/main/java/org/embulk/output/td/RecordWriter.java
+++ b/src/main/java/org/embulk/output/td/RecordWriter.java
@@ -193,8 +193,8 @@ public class RecordWriter
     @Override
     public TaskReport commit()
     {
-        TaskReport report = Exec.newTaskReport();
-        //  TODO
+        TaskReport report = Exec.newTaskReport()
+                .set(TdOutputPlugin.TASK_REPORT_UPLOADED_PART_NUMBER, partSeqId);
         return report;
     }
 }

--- a/src/test/java/org/embulk/output/td/TestRecordWriter.java
+++ b/src/test/java/org/embulk/output/td/TestRecordWriter.java
@@ -245,6 +245,6 @@ public class TestRecordWriter
     public void checkTaskReport()
     {
         recordWriter = recordWriter(task, tdClient(plugin, task), fieldWriters(log, task, schema));
-        assertTrue(recordWriter.commit().isEmpty());
+        assertTrue(recordWriter.commit().has(TdOutputPlugin.TASK_REPORT_UPLOADED_PART_NUMBER));
     }
 }


### PR DESCRIPTION
If users data are not uploaded on bulk_import session, it can skip performing and committing the bulk_import session. This PR implements the optimization.