### PR TITLE
Use TDClient#showTable method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     provided    "org.embulk:embulk-standards:0.8.+"
     compile     "org.msgpack:msgpack-core:0.8.+"
     provided    "org.msgpack:msgpack-core:0.8.+"
-    compile    ("com.treasuredata.client:td-client:0.7.36-SNAPSHOT") { // TODO Use 0.7.36 after releasing it.
+    compile    ("com.treasuredata.client:td-client:0.7.37") {
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "com.fasterxml.jackson.datatype"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     provided    "org.msgpack:msgpack-core:0.8.+"
     compile    ("com.treasuredata.client:td-client:0.7.37") {
         exclude group: "com.fasterxml.jackson.core"
-        exclude group: "com.fasterxml.jackson.datatype"
     }
 
     testCompile "junit:junit:4.+"

--- a/build.gradle
+++ b/build.gradle
@@ -32,17 +32,9 @@ dependencies {
     provided    "org.embulk:embulk-standards:0.8.+"
     compile     "org.msgpack:msgpack-core:0.8.+"
     provided    "org.msgpack:msgpack-core:0.8.+"
-    compile    ("com.treasuredata.client:td-client:0.7.37") {
-        exclude group: "com.fasterxml.jackson.core"
-    }
+    compile    "com.treasuredata.client:td-client:0.7.37"
 
     testCompile "junit:junit:4.+"
-    // td-client requires jackson 2.6.7
-    testCompile "com.fasterxml.jackson.core:jackson-core:2.6.7"
-    testCompile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    testCompile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
-    testCompile "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7"
-    testCompile "com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.6.7"
     testCompile "org.bigtesting:fixd:1.0.0"
     testCompile  "org.embulk:embulk-core:0.8.+:tests"
     testCompile  "org.mockito:mockito-core:1.9.5"

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,18 @@ dependencies {
     provided    "org.embulk:embulk-standards:0.8.+"
     compile     "org.msgpack:msgpack-core:0.8.+"
     provided    "org.msgpack:msgpack-core:0.8.+"
-    compile     "com.treasuredata.client:td-client:0.7.29"
+    compile    ("com.treasuredata.client:td-client:0.7.36-SNAPSHOT") { // TODO Use 0.7.36 after releasing it.
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.datatype"
+    }
 
     testCompile "junit:junit:4.+"
+    // td-client requires jackson 2.6.7
+    testCompile "com.fasterxml.jackson.core:jackson-core:2.6.7"
+    testCompile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+    testCompile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
+    testCompile "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7"
+    testCompile "com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.6.7"
     testCompile "org.bigtesting:fixd:1.0.0"
     testCompile  "org.embulk:embulk-core:0.8.+:tests"
     testCompile  "org.mockito:mockito-core:1.9.5"

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -554,15 +554,10 @@ public class TdOutputPlugin
     void validateTableExists(TDClient client, String databaseName, String tableName)
     {
         try {
-            for (TDTable table : client.listTables(databaseName)) {
-                if (table.getName().equals(tableName)) {
-                    return;
-                }
-            }
-            throw new ConfigException(String.format("Table \"%s\".\"%s\" doesn't exist", databaseName, tableName));
+            client.showTable(databaseName, tableName);
         }
         catch (TDClientHttpNotFoundException ex) {
-            throw new ConfigException(String.format("Database \"%s\" doesn't exist", databaseName), ex);
+            throw new ConfigException(String.format("Database \"%s\" or table \"%s\" doesn't exist", databaseName, tableName), ex);
         }
     }
 
@@ -769,12 +764,12 @@ public class TdOutputPlugin
 
     private static TDTable findTable(TDClient client, String databaseName, String tableName)
     {
-        for (TDTable table : client.listTables(databaseName)) {
-            if (table.getName().equals(tableName)) {
-                return table;
-            }
+        try {
+            return client.showTable(databaseName, tableName);
         }
-        return null;
+        catch(TDClientHttpNotFoundException e) {
+            return null;
+        }
     }
 
     private static final Pattern COLUMN_NAME_PATTERN = Pattern.compile("\\A[a-z_][a-z0-9_]*\\z");

--- a/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
+++ b/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
@@ -1,7 +1,6 @@
 package org.embulk.output.td;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.treasuredata.client.ProxyConfig;
@@ -333,24 +332,13 @@ public class TestTdOutputPlugin
         TDTable table = newTable("my_table", "[]");
 
         { // table exists
-            doReturn(ImmutableList.of(table)).when(client).listTables(anyString());
+            doReturn(table).when(client).showTable(anyString(), anyString());
             plugin.validateTableExists(client, "my_db", "my_table");
             // no error happens
         }
 
-        { // table doesn't exist
-            doReturn(ImmutableList.of()).when(client).listTables(anyString());
-            try {
-                plugin.validateTableExists(client, "my_db", "my_table");
-                fail();
-            }
-            catch (Throwable t) {
-                assertTrue(t instanceof ConfigException);
-            }
-        }
-
-        { // database doesn't exist
-            doThrow(notFound()).when(client).listTables(anyString());
+        { // database or table doesn't exist
+            doThrow(notFound()).when(client).showTable(anyString(), anyString());
             try {
                 plugin.validateTableExists(client, "my_db", "my_table");
                 fail();


### PR DESCRIPTION
This PR replaces the usage of `TDClient#listTables` with `TDClient#showTable` to reduce network traffic. In embulk-output-td, the `listTables` method is used for getting table schema of the specified table. If an user has a lot of tables, the embulk-output-td needs to download all of tables information to get one table schema. Since API will support table/show endpoint, we should use the functionality. This PR also updates td-client-java 0.7.36.

This PR assumes https://github.com/treasure-data/td-client-java/pull/86. 