### PR TITLE
Use table append table schema

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,18 +32,9 @@ dependencies {
     provided    "org.embulk:embulk-standards:0.8.+"
     compile     "org.msgpack:msgpack-core:0.8.+"
     provided    "org.msgpack:msgpack-core:0.8.+"
-    compile    ("com.treasuredata.client:td-client:0.7.36-SNAPSHOT") { // TODO Use 0.7.36 after releasing it.
-        exclude group: "com.fasterxml.jackson.core"
-        exclude group: "com.fasterxml.jackson.datatype"
-    }
+    compile     "com.treasuredata.client:td-client:0.7.37-SNAPSHOT" // TODO Use 0.7.37 after releasing it.
 
     testCompile "junit:junit:4.+"
-    // td-client requires jackson 2.6.7
-    testCompile "com.fasterxml.jackson.core:jackson-core:2.6.7"
-    testCompile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    testCompile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
-    testCompile "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7"
-    testCompile "com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.6.7"
     testCompile "org.bigtesting:fixd:1.0.0"
     testCompile  "org.embulk:embulk-core:0.8.+:tests"
     testCompile  "org.mockito:mockito-core:1.9.5"

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     provided    "org.embulk:embulk-standards:0.8.+"
     compile     "org.msgpack:msgpack-core:0.8.+"
     provided    "org.msgpack:msgpack-core:0.8.+"
-    compile    "com.treasuredata.client:td-client:0.7.37"
+    compile    "com.treasuredata.client:td-client:0.7.38"
 
     testCompile "junit:junit:4.+"
     testCompile "org.bigtesting:fixd:1.0.0"

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -748,7 +748,7 @@ public class TdOutputPlugin
             newSchema.add(new TDColumn(pair.getKey(), pair.getValue(), key.getBytes(StandardCharsets.UTF_8)));
         }
 
-        client.updateTableSchema(databaseName, task.getLoadTargetTableName(), newSchema);
+        client.appendTableSchema(databaseName, task.getLoadTargetTableName(), newSchema);
         return guessedSchema;
     }
 


### PR DESCRIPTION
This PR replaces the usage of `TDClient#updateTableSchema` with `#appendTableSchema` for import_only accounts' write_only keys. Because they don't allow the usage of `TDClient#updateTableSchema`. This change should work for normal accounts' master/write_only keys and import_only accounts' master keys as well. 

This PR assumes https://github.com/treasure-data/embulk-output-td/pull/64 and Embulk 0.8.20.