### PR TITLE
Check if Embulk version is 0.8.22+

### DIFF
--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -33,6 +33,7 @@ import com.treasuredata.client.model.TDBulkImportSession.ImportStatus;
 import com.treasuredata.client.model.TDColumn;
 import com.treasuredata.client.model.TDColumnType;
 import com.treasuredata.client.model.TDTable;
+import org.embulk.EmbulkVersion;
 import org.embulk.config.TaskReport;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -354,6 +355,15 @@ public class TdOutputPlugin
 
         if (!task.getTempDir().isPresent()) {
             task.setTempDir(Optional.of(getEnvironmentTempDirectory()));
+        }
+
+        // Embulk v0.8.21 and lower version uses old Jackson and doesn't works with this plugin
+        // https://github.com/embulk/embulk/pull/615
+        String[] versions = EmbulkVersion.VERSION.split("\\.");
+        if (versions.length == 3) {
+            if (Integer.valueOf(versions[1]) <= 8 && Integer.valueOf(versions[2]) < 22) {
+                throw new ConfigException("embulk-output-td v0.4.x+ only supports Embulk v0.8.22 or higher versions");
+            }
         }
 
         try (TDClient client = newTDClient(task)) {

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -357,14 +357,7 @@ public class TdOutputPlugin
             task.setTempDir(Optional.of(getEnvironmentTempDirectory()));
         }
 
-        // Embulk v0.8.21 and lower version uses old Jackson and doesn't works with this plugin
-        // https://github.com/embulk/embulk/pull/615
-        String[] versions = EmbulkVersion.VERSION.split("\\.");
-        if (versions.length == 3) {
-            if (Integer.valueOf(versions[1]) <= 8 && Integer.valueOf(versions[2]) < 22) {
-                throw new ConfigException("embulk-output-td v0.4.x+ only supports Embulk v0.8.22 or higher versions");
-            }
-        }
+        checkEmbulkVersion();
 
         try (TDClient client = newTDClient(task)) {
             String databaseName = task.getDatabase();
@@ -825,6 +818,21 @@ public class TdOutputPlugin
                 return null;
             }
         });
+    }
+
+    private void checkEmbulkVersion()
+    {
+        // Embulk v0.8.21 and lower version uses old Jackson and doesn't works with this plugin
+        // https://github.com/embulk/embulk/pull/615
+        String[] versionNumber = EmbulkVersion.VERSION.split("-"); // to split e.g. "0.8.26-SNAPSHOT" or "0.8.30-ALPHA1"
+        if (versionNumber[0] != null) {
+            String[] versions = versionNumber[0].split("\\.");
+            if (versions.length == 3) {
+                if (Integer.valueOf(versions[1]) <= 8 && Integer.valueOf(versions[2]) < 22) {
+                    throw new ConfigException("embulk-output-td v0.4.x+ only supports Embulk v0.8.22 or higher versions");
+                }
+            }
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
We are no longer supports Embulk v0.8.21 or lower versions since we're going to update td-client-java and it uses Jackson v2.6.7. #64 #65 
Embulk also uses [Jackson v2.6.7](https://github.com/embulk/embulk/pull/615) since [v0.8.22](http://www.embulk.org/docs/release/release-0.8.22.html). Then, Embulk v0.8.21 or lower version doesn't works with this plugin.