### PR TITLE
Fix Embulk version check logic

### DIFF
--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -821,6 +821,8 @@ public class TdOutputPlugin
         // https://github.com/embulk/embulk/pull/615
         boolean isValidVersion = true;
         try {
+            // Embulk v0.8.18 or lower version doesn't have class org.embulk.EmbulkVersion
+            Class.forName("org.embulk.EmbulkVersion");
             String[] versionNumber = EmbulkVersion.VERSION.split("-"); // to split e.g. "0.8.26-SNAPSHOT" or "0.8.30-ALPHA1"
             if (versionNumber[0] != null) {
                 String[] versions = versionNumber[0].split("\\.");
@@ -831,8 +833,7 @@ public class TdOutputPlugin
                 }
             }
         }
-        catch (NoClassDefFoundError ex) {
-            // Embulk v0.8.18 or lower version doesn't have class org.embulk.EmbulkVersion
+        catch (ClassNotFoundException ex) {
             isValidVersion = false;
         }
         if (!isValidVersion) {

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -819,14 +819,24 @@ public class TdOutputPlugin
     {
         // Embulk v0.8.21 and lower version uses old Jackson and doesn't works with this plugin
         // https://github.com/embulk/embulk/pull/615
-        String[] versionNumber = EmbulkVersion.VERSION.split("-"); // to split e.g. "0.8.26-SNAPSHOT" or "0.8.30-ALPHA1"
-        if (versionNumber[0] != null) {
-            String[] versions = versionNumber[0].split("\\.");
-            if (versions.length == 3) {
-                if (Integer.valueOf(versions[1]) <= 8 && Integer.valueOf(versions[2]) < 22) {
-                    throw new ConfigException("embulk-output-td v0.4.x+ only supports Embulk v0.8.22 or higher versions");
+        boolean isValidVersion = true;
+        try {
+            String[] versionNumber = EmbulkVersion.VERSION.split("-"); // to split e.g. "0.8.26-SNAPSHOT" or "0.8.30-ALPHA1"
+            if (versionNumber[0] != null) {
+                String[] versions = versionNumber[0].split("\\.");
+                if (versions.length == 3) {
+                    if (Integer.valueOf(versions[1]) <= 8 && Integer.valueOf(versions[2]) < 22) {
+                        isValidVersion = false;
+                    }
                 }
             }
+        }
+        catch (NoClassDefFoundError ex) {
+            // Embulk v0.8.18 or lower version doesn't have class org.embulk.EmbulkVersion
+            isValidVersion = false;
+        }
+        if (!isValidVersion) {
+            throw new ConfigException("embulk-output-td v0.4.x+ only supports Embulk v0.8.22 or higher versions");
         }
     }
 


### PR DESCRIPTION
I implemented Embulk version check at #74 because embulk-output-td v0.4.x+ only works with Embulk v0.8.21+.

However I found that Embulk v0.8.18 or lower version doesn't have `org.embulk.EmbulkVersion` class and caused `java.lang.NoClassDefFoundError: org/embulk/EmbulkVersion`.

I changed implementation to throw ConfigException when above class doesn't exists.

### Stacktrace
```
$ embulk run load.yml
2017-08-10 12:12:42.820 +0900: Embulk v0.8.18
2017-08-10 12:12:45.763 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-td (0.4.1)
2017-08-10 12:12:45.833 +0900 [INFO] (0001:transaction): Listing local files at directory '/Users/someone/Documents/work/Embulk/output-td-0.4.1-bug' filtering filename by prefix 'test'
2017-08-10 12:12:45.840 +0900 [INFO] (0001:transaction): Loading files [/Users/someone/Documents/work/Embulk/output-td-0.4.1-bug/test.csv]
2017-08-10 12:12:45.915 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4
org.embulk.exec.PartialExecutionException: java.lang.NoClassDefFoundError: org/embulk/EmbulkVersion
	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(org/embulk/exec/BulkLoader.java:373)
	at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:591)
	at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:33)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:389)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:385)
	at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:25)
	at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:385)
	at org.embulk.EmbulkEmbed.run(org/embulk/EmbulkEmbed.java:180)
	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:453)
	at org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:314)
	at RUBY.run(/Users/someone/.embulk/bin/embulk!/embulk/runner.rb:84)
	at RUBY.run(/Users/someone/.embulk/bin/embulk!/embulk/command/embulk_run.rb:307)
	at RUBY.<main>(/Users/someone/.embulk/bin/embulk!/embulk/command/embulk_main.rb:2)
	at org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:850)
	at org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2976)
	at org.jruby.RubyKernel.requireCommon(org/jruby/RubyKernel.java:963)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:956)
	at org.jruby.RubyKernel$INVOKER$s$1$0$require19.call(org/jruby/RubyKernel$INVOKER$s$1$0$require19.gen)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1)
	at Users.someone.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.invokeOther66:require(Users/someone/$_dot_embulk/bin/embulk/embulk/command/file:/Users/someone/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
	at Users.someone.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.<main>(file:/Users/someone/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
	at java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle.java:627)
	at org.jruby.Ruby.runScript(org/jruby/Ruby.java:834)
	at org.jruby.Ruby.runNormally(org/jruby/Ruby.java:749)
	at org.jruby.Ruby.runNormally(org/jruby/Ruby.java:767)
	at org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:580)
	at org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
	at org.jruby.Main.internalRun(org/jruby/Main.java:313)
	at org.jruby.Main.run(org/jruby/Main.java:242)
	at org.jruby.Main.main(org/jruby/Main.java:204)
	at org.embulk.cli.Main.main(org/embulk/cli/Main.java:23)
	Suppressed: java.lang.NullPointerException
		at org.embulk.exec.BulkLoader.doCleanup(BulkLoader.java:494)
		at org.embulk.exec.BulkLoader$3.run(BulkLoader.java:425)
		at org.embulk.exec.BulkLoader$3.run(BulkLoader.java:421)
		at org.embulk.spi.Exec.doWith(Exec.java:25)
		at org.embulk.exec.BulkLoader.cleanup(BulkLoader.java:421)
		at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:184)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.lang.reflect.Method.invoke(Method.java:498)
		at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:453)
		at org.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:314)
		at org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:46)
		at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
		at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
		at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
		at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:90)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:214)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:200)
		at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:205)
		at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:358)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:195)
		at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:324)
		at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
		at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:84)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:179)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
		at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
		at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
		at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
		at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
		at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:112)
		at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:99)
		at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
		at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
		at org.jruby.Ruby.runInterpreter(Ruby.java:850)
		at org.jruby.Ruby.loadFile(Ruby.java:2976)
		at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:243)
		at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:34)
		at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:885)
		at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:525)
		at org.jruby.runtime.load.LoadService.require(LoadService.java:396)
		at org.jruby.RubyKernel.requireCommon(RubyKernel.java:963)
		at org.jruby.RubyKernel.require19(RubyKernel.java:956)
		at org.jruby.RubyKernel$INVOKER$s$1$0$require19.call(RubyKernel$INVOKER$s$1$0$require19.gen)
		at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrNBlock.call(JavaMethod.java:383)
		at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:61)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:161)
		at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
		at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
		at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:84)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:179)
		at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
		at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
		at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
		at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
		at Users.someone.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.invokeOther66:require(file:/Users/someone/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
		at Users.someone.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.RUBY$script(file:/Users/someone/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
		at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
		at org.jruby.ir.Compiler$1.load(Compiler.java:111)
		at org.jruby.Ruby.runScript(Ruby.java:834)
		at org.jruby.Ruby.runNormally(Ruby.java:749)
		at org.jruby.Ruby.runNormally(Ruby.java:767)
		at org.jruby.Ruby.runFromMain(Ruby.java:580)
		at org.jruby.Main.doRunFromMain(Main.java:425)
		at org.jruby.Main.internalRun(Main.java:313)
		at org.jruby.Main.run(Main.java:242)
		at org.jruby.Main.main(Main.java:204)
		at org.embulk.cli.Main.main(Main.java:23)
Caused by: java.lang.NoClassDefFoundError: org/embulk/EmbulkVersion
	at org.embulk.output.td.TdOutputPlugin.checkEmbulkVersion(TdOutputPlugin.java:822)
	at org.embulk.output.td.TdOutputPlugin.transaction(TdOutputPlugin.java:360)
	at org.embulk.exec.BulkLoader$4$1$1.transaction(BulkLoader.java:544)
	at org.embulk.exec.LocalExecutorPlugin.transaction(LocalExecutorPlugin.java:54)
	at org.embulk.exec.BulkLoader$4$1.run(BulkLoader.java:539)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:96)
	at org.embulk.spi.util.Filters.transaction(Filters.java:49)
	at org.embulk.exec.BulkLoader$4.run(BulkLoader.java:533)
	at org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(FileInputRunner.java:123)
	at org.embulk.standards.CsvParserPlugin.transaction(CsvParserPlugin.java:225)
	at org.embulk.spi.FileInputRunner$RunnerControl$1.run(FileInputRunner.java:117)
	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:77)
	at org.embulk.spi.util.Decoders.transaction(Decoders.java:33)
	at org.embulk.spi.FileInputRunner$RunnerControl.run(FileInputRunner.java:114)
	at org.embulk.standards.LocalFileInputPlugin.resume(LocalFileInputPlugin.java:79)
	at org.embulk.standards.LocalFileInputPlugin.transaction(LocalFileInputPlugin.java:69)
	at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:65)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:528)
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:389)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:385)
	at org.embulk.spi.Exec.doWith(Exec.java:25)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:385)
	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:180)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:453)
	at org.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:314)
	at org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:46)
	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:90)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:214)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:200)
	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:205)
	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:358)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:195)
	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:324)
	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:84)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:179)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:112)
	at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:99)
	at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
	at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
	at org.jruby.Ruby.runInterpreter(Ruby.java:850)
	at org.jruby.Ruby.loadFile(Ruby.java:2976)
	at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:243)
	at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:34)
	at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:885)
	at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:525)
	at org.jruby.runtime.load.LoadService.require(LoadService.java:396)
	at org.jruby.RubyKernel.requireCommon(RubyKernel.java:963)
	at org.jruby.RubyKernel.require19(RubyKernel.java:956)
	at org.jruby.RubyKernel$INVOKER$s$1$0$require19.call(RubyKernel$INVOKER$s$1$0$require19.gen)
	at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrNBlock.call(JavaMethod.java:383)
	at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:61)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:161)
	at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:315)
	at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:84)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:179)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
	at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
	at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
	at Users.someone.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.invokeOther66:require(file:/Users/someone/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
	at Users.someone.$_dot_embulk.bin.embulk.embulk.command.embulk_bundle.RUBY$script(file:/Users/someone/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:51)
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
	at org.jruby.ir.Compiler$1.load(Compiler.java:111)
	at org.jruby.Ruby.runScript(Ruby.java:834)
	at org.jruby.Ruby.runNormally(Ruby.java:749)
	at org.jruby.Ruby.runNormally(Ruby.java:767)
	at org.jruby.Ruby.runFromMain(Ruby.java:580)
	at org.jruby.Main.doRunFromMain(Main.java:425)
	at org.jruby.Main.internalRun(Main.java:313)
	at org.jruby.Main.run(Main.java:242)
	at org.jruby.Main.main(Main.java:204)
	at org.embulk.cli.Main.main(Main.java:23)
Caused by: java.lang.ClassNotFoundException: org.embulk.EmbulkVersion
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at org.embulk.plugin.PluginClassLoader.loadClass(PluginClassLoader.java:83)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 89 more

Error: java.lang.NoClassDefFoundError: org/embulk/EmbulkVersion
```