### PR TITLE
Support resource pool name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     provided    "org.embulk:embulk-standards:0.8.+"
     compile     "org.msgpack:msgpack-core:0.8.+"
     provided    "org.msgpack:msgpack-core:0.8.+"
-    compile    "com.treasuredata.client:td-client:0.7.41"
+    compile    "com.treasuredata.client:td-client:0.8.3"
 
     testCompile "junit:junit:4.+"
     testCompile "org.bigtesting:fixd:1.0.0"

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -179,6 +179,10 @@ public class TdOutputPlugin
         @ConfigDefault("90000")
         int getRetryMaxIntervalMillis();
 
+        @Config("pool_name")
+        @ConfigDefault("null")
+        public Optional<String> getPoolName();
+
         public boolean getDoUpload();
         public void setDoUpload(boolean doUpload);
 
@@ -633,7 +637,7 @@ public class TdOutputPlugin
                 }
             }
             // perform
-            client.performBulkImportSession(sessionName); // TODO use priority
+            client.performBulkImportSession(sessionName, task.getPoolName()); // TODO use priority
 
             // pass
         case PERFORMING:

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -466,7 +466,7 @@ public class TdOutputPlugin
         builder.setEndpoint(task.getEndpoint());
         builder.setUseSSL(task.getUseSsl());
         builder.setConnectTimeoutMillis(60000); // default 15000
-        builder.setIdleTimeoutMillis(60000); // default 60000
+        builder.setReadTimeoutMillis(60000); // default 60000
         builder.setRetryLimit(task.getRetryLimit());
         builder.setRetryInitialIntervalMillis(task.getRetryInitialIntervalMillis());
         builder.setRetryMaxIntervalMillis(task.getRetryMaxIntervalMillis());

--- a/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
+++ b/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
@@ -452,7 +452,7 @@ public class TestTdOutputPlugin
 
         TDClient client = spy(plugin.newTDClient(task));
         doNothing().when(client).freezeBulkImportSession(anyString());
-        doNothing().when(client).performBulkImportSession(anyString());
+        doNothing().when(client).performBulkImportSession(anyString(), any(Optional.class));
         doNothing().when(client).commitBulkImportSession(anyString());
 
         { // uploading + unfreeze


### PR DESCRIPTION
The resource pool name is optional, default is null and it will be ignored if it's null.

The PR also include the fixing for making it compatible with the latest td-client-java.