### PR TITLE
Use Java8 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk7
+jdk: oraclejdk8
 
 script: ./gradlew clean test
 


### PR DESCRIPTION
I noticed Travis CI fails with master branch.
https://travis-ci.org/treasure-data/embulk-output-td/builds/364033616
```sh
ERROR: JAVA_HOME is set to an invalid directory: /usr/lib/jvm/java-7-oracle
Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.
The command "eval ./gradlew assemble " failed. Retrying, 2 of 3.
```

I think we can use Oracle JDK 8 if we merge https://github.com/treasure-data/embulk-output-td/pull/81 because td-client-java 0.8.0 requires Java 1.8 or higher.