### PR TITLE
add CircleCI supports Java8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+machine:
+  java:
+    version: oraclejdk8
+
+test:
+  override:
+    - ./gradlew clean checkstyle check jacocoTestReport
+  post:
+    - cp -R build/reports/* $CIRCLE_ARTIFACTS
+
+notify:
+  webhooks:
+    - url: http://td-beda.herokuapp.com/circleci_callback

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 test:
   override:
-    - ./gradlew clean checkstyle check jacocoTestReport
+    - ./gradlew clean check jacocoTestReport
   post:
     - cp -R build/reports/* $CIRCLE_ARTIFACTS
 


### PR DESCRIPTION
CircleCI configuration file does not exist and it detects the wrong JDK version, the new CircleCI configuration will specify JDK version instead of let CircleCI guess it.