### PR TITLE
Use OpenJDK8 instead of OracleJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 
 script: ./gradlew clean test
 


### PR DESCRIPTION
I got a CI failure with Oracle JDK8.
```
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 7 during .
```
https://travis-ci.org/treasure-data/embulk-output-td/builds/550683654

I think this is related to below issues.
https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038
https://github.com/travis-ci/travis-ci/issues/10290