### PR TITLE
Fix issue #91 column order changed

### DIFF
--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -2,6 +2,7 @@ package org.embulk.output.td;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
@@ -691,7 +692,7 @@ public class TdOutputPlugin
         String databaseName = task.getDatabase();
         TDTable table = findTable(client, databaseName, task.getTable());
 
-        final Map<String, TDColumnType> guessedSchema = new HashMap<>();
+        final Map<String, TDColumnType> guessedSchema = new LinkedHashMap<>();
         inputSchema.visitColumns(new ColumnVisitor() {
             public void booleanColumn(Column column)
             {


### PR DESCRIPTION
Fixed issue [91](https://github.com/treasure-data/embulk-output-td/issues/91) .The columns order changed due to HashMap by default will re-order bases on its key (column name). Switch to use LinkedHashMap to keep column index as is