### PR TITLE
Add the new option ignore_alternative_time_if_time_exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.1 - 2020-05-11
+* [new feature] Added new configuration `ignore_alternative_time_if_time_exists` [#95](https://github.com/treasure-data/embulk-output-td/pull/95)
+
 ## 0.6.0 - 2020-03-05
 * Build with the "org.embulk.embulk-plugins" Gradle plugin
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 - **retry_max_interval_millis**: the maximum intervals. The interval doubles every retry until retry_max_interval_millis is reached. (int, default: 90000)
 - **additional_http_headers**: add additional headers to the requests (a key & value map, default: null)
 - **port**: set port for Http requests. By default will connect to port 443 or 80 if `use_ssl: false` (int, optional)
-- **ignore_alternative_time_if_time_exists**: ignore `time_column` and `time_value` in configuration if `time` column in input schema exists. (boolean, default: false)
+- **ignore_alternative_time_if_time_exists**: ignore `time_column` and `time_value` in the configuration if a `time` column exists in the input schema. (boolean, default: false)
 
 ## Modes
 * **append**:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - **retry_max_interval_millis**: the maximum intervals. The interval doubles every retry until retry_max_interval_millis is reached. (int, default: 90000)
 - **additional_http_headers**: add additional headers to the requests (a key & value map, default: null)
 - **port**: set port for Http requests. By default will connect to port 443 or 80 if `use_ssl: false` (int, optional)
+- **ignore_alternative_time_if_time_exists**: ignore `time_column` and `time_value` in configuration if `time` column in input schema exists. (boolean, default: false)
 
 ## Modes
 * **append**:

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 group = "org.embulk.output.td"
-version = "0.6.0"
+version = "0.6.1"
 description = "TreasureData output plugin is an Embulk plugin that loads records to TreasureData read by any input plugins. Search the input plugins by 'embulk-output' keyword."
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -120,6 +120,10 @@ public class TdOutputPlugin
         Optional<TimeValueConfig> getTimeValue(); // TODO allow timestamp format such as {from: "2015-01-01 00:00:00 UTC", to: "2015-01-02 00:00:00 UTC"} as well as unixtime integer
         void setTimeValue(Optional<TimeValueConfig> timeValue);
 
+        @Config("ignore_alternative_time_if_time_exists")
+        @ConfigDefault("false")
+        boolean getIgnoreAlternativeTimeIfTimeExists();
+
         @Config("unix_timestamp_unit")
         @ConfigDefault("\"sec\"")
         UnixTimestampUnit getUnixTimestampUnit();

--- a/src/main/java/org/embulk/output/td/writer/FieldWriterSet.java
+++ b/src/main/java/org/embulk/output/td/writer/FieldWriterSet.java
@@ -48,9 +48,12 @@ public class FieldWriterSet
 
     public static FieldWriterSet createWithValidation(Logger log, TdOutputPlugin.PluginTask task, Schema schema, boolean runStage)
     {
-        Optional<String> userDefinedPrimaryKeySourceColumnName = task.getTimeColumn();
+        boolean isIgnoreAlternativeTime = task.getIgnoreAlternativeTimeIfTimeExists()
+                && schema.getColumns().stream().anyMatch(column -> "time".equals(column.getName()));
+        Optional<String> userDefinedPrimaryKeySourceColumnName = isIgnoreAlternativeTime ? Optional.absent() : task.getTimeColumn();
         ConvertTimestampType convertTimestampType = task.getConvertTimestampType();
-        Optional<TimeValueConfig> timeValueConfig = task.getTimeValue();
+        Optional<TimeValueConfig> timeValueConfig = isIgnoreAlternativeTime ? Optional.absent() : task.getTimeValue();
+
         if (timeValueConfig.isPresent() && userDefinedPrimaryKeySourceColumnName.isPresent()) {
             throw new ConfigException("Setting both time_column and time_value is invalid");
         }

--- a/src/test/java/org/embulk/output/td/writer/TestFieldWriterSet.java
+++ b/src/test/java/org/embulk/output/td/writer/TestFieldWriterSet.java
@@ -133,6 +133,17 @@ public class TestFieldWriterSet
             assertTrue(writers.getFieldWriter(0) instanceof UnixTimestampFieldDuplicator); // c0
             assertTrue(writers.getFieldWriter(1) instanceof TimestampStringFieldWriter); // renamed column
         }
+
+        { // time_column option (long type) is ignored if time column exists and ignore_alternative_time is enabled
+            Schema schema = schema("_c0", Types.LONG, "time", Types.TIMESTAMP);
+            FieldWriterSet writers = FieldWriterSet.createWithValidation(log, pluginTask(config
+                    .deepCopy()
+                    .set("time_column", "_c0")
+                    .set("ignore_alternative_time_if_time_exists", true)), schema, false);
+
+            assertTrue(writers.getFieldWriter(0) instanceof LongFieldWriter); // c0
+            assertTrue(writers.getFieldWriter(1) instanceof TimestampLongFieldWriter); // time primary key
+        }
     }
 
     @Test


### PR DESCRIPTION
**Context:** The current behavior if `time` column is available in schema and either `time_column` or `time_value` is specified:
1.  `time` column will be renamed to `time_`
2. either `time_column` or `time_value` will be added as a replacement for the new `time` column depends on the value of those 2 fields.

The new option `ignore_alternative_time_if_time_exists` is added so that it allows us to ignore `time_column` or `time_value` from configuration and use `time` column from schema if it exists. It gives us the possibility to still keep the those values in configuration but tweak the behavior of exporting `time` to TD.

The default of that configuration field is false so that it keeps the backward compatibility with the existing behavior.