### PR TITLE
Stop using Exec.session()

### DIFF
--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -32,7 +32,6 @@ import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.DataException;
 import org.embulk.spi.Exec;
-import org.embulk.spi.ExecSession;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
@@ -371,7 +370,7 @@ public class TdOutputPlugin
         checkColumnOptions(schema, task.getColumnOptions());
 
         // generate session name
-        task.setSessionName(buildBulkImportSessionName(task, Exec.session()));
+        task.setSessionName(buildBulkImportSessionName(task));
 
         if (!task.getTempDir().isPresent()) {
             task.setTempDir(Optional.of(getEnvironmentTempDirectory()));
@@ -603,13 +602,13 @@ public class TdOutputPlugin
     }
 
     @VisibleForTesting
-    String buildBulkImportSessionName(PluginTask task, ExecSession exec)
+    String buildBulkImportSessionName(PluginTask task)
     {
         if (task.getSession().isPresent()) {
             return task.getSession().get();
         }
         else {
-            Timestamp time = exec.getTransactionTime(); // TODO implement Exec.getTransactionUniqueName()
+            Timestamp time = Exec.getTransactionTime(); // TODO implement Exec.getTransactionUniqueName()
             final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
                     .withZone(ZoneOffset.UTC);
             return String.format("embulk_%s_%09d_%s",

--- a/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
+++ b/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
@@ -29,7 +29,6 @@ import org.embulk.output.td.TdOutputPlugin.UnixTimestampUnit;
 import org.embulk.output.td.writer.FieldWriterSet;
 import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
-import org.embulk.spi.ExecSession;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfigException;
@@ -174,7 +173,7 @@ public class TestTdOutputPlugin
     @Test
     public void transaction()
     {
-        doReturn("session_name").when(plugin).buildBulkImportSessionName(any(PluginTask.class), any(ExecSession.class));
+        doReturn("session_name").when(plugin).buildBulkImportSessionName(any(PluginTask.class));
         ConfigDiff configDiff = Exec.newConfigDiff().set("last_session", "session_name");
         doReturn(configDiff).when(plugin).doRun(any(TDClient.class), any(Schema.class), any(PluginTask.class), any(OutputPlugin.Control.class));
         Schema schema = schema("time", Types.LONG, "c0", Types.STRING, "c1", Types.STRING);
@@ -375,12 +374,12 @@ public class TestTdOutputPlugin
     {
         { // session option is specified
             PluginTask task = pluginTask(config.deepCopy().set("session", "my_session"));
-            assertEquals("my_session", plugin.buildBulkImportSessionName(task, Exec.session()));
+            assertEquals("my_session", plugin.buildBulkImportSessionName(task));
         }
 
         { // session is not specified as option
             PluginTask task = pluginTask(config);
-            assertTrue(plugin.buildBulkImportSessionName(task, Exec.session()).startsWith("embulk_"));
+            assertTrue(plugin.buildBulkImportSessionName(task).startsWith("embulk_"));
         }
     }
 


### PR DESCRIPTION
`embulk-core` would be removing `Exec.session()` and access to `ExecSession`. This plugin does not look necessary to get `Exec.session().getTransactionTime()` instead of just `Exec.getTransactionTime()`...