### PR TITLE
Ignore appending 'v' column to table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.1 - 2021-02-01
+* [maintenance] Ignore appending 'v' column to table [#105](https://github.com/treasure-data/embulk-output-td/pull/105)
+
 ## 0.7.0 - 2020-09-15
 * [new feature] Added additional `column_options` configurations to customize TD's type [#98](https://github.com/treasure-data/embulk-output-td/pull/98)
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 group = "org.embulk.output.td"
-version = "0.7.0"
+version = "0.7.1"
 description = "TreasureData output plugin is an Embulk plugin that loads records to TreasureData read by any input plugins. Search the input plugins by 'embulk-output' keyword."
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -782,6 +782,10 @@ public class TdOutputPlugin
             }
         }
         guessedSchema.remove("time"); // don't change type of 'time' column
+        // 'v' column is special column in TD's table, it is reserved column to be used in Hive
+        // by executing `SELECT *` query, thus it must not be appended
+        // otherwise 422 response code will be responded.
+        guessedSchema.remove("v");
 
         List<TDColumn> newSchema;
         if (task.getMode() != Mode.REPLACE) {
@@ -791,7 +795,6 @@ public class TdOutputPlugin
             newSchema = Lists.newArrayList();
         }
 
-        // FIXME: Better variable name?
         final Map<String, TDColumnType> appliedColumnOptionSchema = applyColumnOptions(guessedSchema, task.getColumnOptions());
         for (Map.Entry<String, TDColumnType> pair : appliedColumnOptionSchema.entrySet()) {
             String key = renameColumn(pair.getKey());


### PR DESCRIPTION
**Context**: TD's table treats 'v' column name as a reserved column name for Hive engine, it forbids any request that touches the column. The PR will remove 'v' column name out of appended columns to TD's table so that it follows the contract between 2 sides and ensure that column name is not touched.

It should not bring any incompatibility to the previous version because for the time being even if during the bulk import processes, 'v' is sent but at the bulk import commit phase, that column will be dropped in TD's side.

Issue: https://github.com/treasure-data/embulk-output-td/issues/106