### PR TITLE
Upgrade okhttp lib from 3.14.7 to 4.9.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: alpine:3.15
+    steps:
+      - run:
+          name: Init Build
+          command: |
+            echo 'init CI build'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = "com.treasuredata.embulk.plugins"
-version = "0.8.1-SNAPSHOT"
+version = "0.8.2-SNAPSHOT"
 description = "TreasureData output plugin is an Embulk plugin that loads records to Treasure Data read by any input plugins."
 
 sourceCompatibility = 1.8
@@ -58,6 +58,7 @@ dependencies {
         // slf4j-api is included in embulk-api's dependencies.
         exclude group: "org.slf4j", module: "slf4j-api"
     }
+    compile "com.squareup.okhttp3:okhttp:4.9.3"
 
     compile("org.embulk:embulk-util-config:0.3.1") {
         // They conflict with embulk-core.

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -16,8 +16,8 @@ com.google.inject:guice:4.0
 com.google.j2objc:j2objc-annotations:1.1
 com.googlecode.json-simple:json-simple:1.1.1
 com.squareup.okhttp3:okhttp-urlconnection:3.14.7
-com.squareup.okhttp3:okhttp:3.14.7
-com.squareup.okio:okio:1.17.2
+com.squareup.okhttp3:okhttp:4.9.3
+com.squareup.okio:okio:2.8.0
 com.treasuredata.client:td-client:0.9.5
 javax.annotation:javax.annotation-api:1.2
 javax.inject:javax.inject:1
@@ -29,4 +29,7 @@ org.embulk:embulk-util-config:0.3.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1
 org.hamcrest:hamcrest-core:1.1
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10
+org.jetbrains.kotlin:kotlin-stdlib:1.4.10
+org.jetbrains:annotations:13.0
 org.json:json:20171018


### PR DESCRIPTION
OkHttp `3.x` causes JVM 11 to hang with HTTP/2 https://github.com/square/okhttp/issues/5832

This PR:
- upgrade okhttp to version 4.9.3
- add config.yml to fix the build error when automate trigger CI job