### PR TITLE
Remove UUID from buildBulkImportSessionName

### DIFF
--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -670,9 +670,9 @@ public class TdOutputPlugin
             final Instant transactionTime = getTransactionTime();
             final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
                     .withZone(ZoneOffset.UTC);
-            return String.format("embulk_%s_%09d_%s",
+            return String.format("embulk_%s_%09d",
                     dateTimeFormatter.format(transactionTime),
-                    transactionTime.getNano(), UUID.randomUUID().toString().replace('-', '_'));
+                    transactionTime.getNano());
         }
     }
 


### PR DESCRIPTION
ref: https://github.com/treasure-data/embulk-output-td/issues/127
Removed UUID from the suffix to allow longer table names with the REPLACE and TRUNCATE options.
