### PR TITLE
Avoid stuck execution due to killed bulk import perform job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = "com.treasuredata.embulk.plugins"
-version = "0.8.2-SNAPSHOT"
+version = "0.8.3-SNAPSHOT"
 description = "TreasureData output plugin is an Embulk plugin that loads records to Treasure Data read by any input plugins."
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/output/td/BulkImportPerformJobKilledException.java
+++ b/src/main/java/org/embulk/output/td/BulkImportPerformJobKilledException.java
@@ -1,0 +1,9 @@
+package org.embulk.output.td;
+
+public class BulkImportPerformJobKilledException extends RuntimeException
+{
+    public BulkImportPerformJobKilledException(String jobId)
+    {
+        super(String.format("The bulk import perform job with ID: '%s' was killed.", jobId));
+    }
+}

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -17,6 +17,8 @@ import com.treasuredata.client.model.TDBulkImportSession;
 import com.treasuredata.client.model.TDBulkImportSession.ImportStatus;
 import com.treasuredata.client.model.TDColumn;
 import com.treasuredata.client.model.TDColumnType;
+import com.treasuredata.client.model.TDJob;
+import com.treasuredata.client.model.TDJobSummary;
 import com.treasuredata.client.model.TDTable;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
@@ -739,7 +741,7 @@ public class TdOutputPlugin
             log.info("Performing bulk import session '{}'", sessionName);
             session = waitForStatusChange(client, sessionName,
                     ImportStatus.PERFORMING, ImportStatus.READY,
-                    "perform");
+                    "perform", true);
             log.info("    job id: {}", session.getJobId());
 
             // pass
@@ -770,7 +772,7 @@ public class TdOutputPlugin
         case COMMITTING:
             session = waitForStatusChange(client, sessionName,
                     ImportStatus.COMMITTING, ImportStatus.COMMITTED,
-                    "commit");
+                    "commit", false);
 
             // pass
         case COMMITTED:
@@ -939,11 +941,24 @@ public class TdOutputPlugin
 
     @VisibleForTesting
     TDBulkImportSession waitForStatusChange(TDClient client, String sessionName,
-            ImportStatus current, ImportStatus expecting, String operation)
+            ImportStatus current, ImportStatus expecting, String operation, boolean isCheckingJobStatus)
     {
         TDBulkImportSession importSession;
+        int count = 0;
         while (true) {
             importSession = client.getBulkImportSession(sessionName);
+
+            // Check if the job has been killed or not, otherwise it will be stuck forever.
+            if (isCheckingJobStatus && count > 20) {
+                if (importSession.getJobId() != null) {
+                    TDJobSummary jobSummary = client.jobStatus(importSession.getJobId());
+                    if (jobSummary.getStatus() == TDJob.Status.KILLED) {
+                        throw new BulkImportPerformJobKilledException(jobSummary.getJobId());
+                    }
+                }
+                count = 0; // reset count after checking job status
+            }
+            count++;
 
             if (importSession.getStatus() == expecting) {
                 return importSession;

--- a/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
+++ b/src/test/java/org/embulk/output/td/TestTdOutputPlugin.java
@@ -64,6 +64,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -467,7 +468,7 @@ public class TestTdOutputPlugin
         PluginTask task = pluginTask(config);
         Schema schema = schema("c0", Types.LONG);
 
-        doReturn(session(UNKNOWN, false)).when(plugin).waitForStatusChange(any(TDClient.class), anyString(), any(ImportStatus.class), any(ImportStatus.class), anyString());
+        doReturn(session(UNKNOWN, false)).when(plugin).waitForStatusChange(any(TDClient.class), anyString(), any(ImportStatus.class), any(ImportStatus.class), anyString(), anyBoolean());
         doReturn(new HashMap<String, TDColumnType>()).when(plugin).updateSchema(any(TDClient.class), any(Schema.class), any(PluginTask.class));
 
         TDClient client = spy(plugin.newTDClient(task));
@@ -537,12 +538,12 @@ public class TestTdOutputPlugin
 
         { // performing -> ready
             doReturn(session(PERFORMING, false)).doReturn(session(READY, false)).when(client).getBulkImportSession("my_session");
-            plugin.waitForStatusChange(client, "my_session", PERFORMING, READY, "");
+            plugin.waitForStatusChange(client, "my_session", PERFORMING, READY, "", true);
         }
 
         { // committing -> committed
             doReturn(session(COMMITTING, false)).doReturn(session(COMMITTED, false)).when(client).getBulkImportSession("my_session");
-            plugin.waitForStatusChange(client, "my_session", COMMITTING, COMMITTED, "");
+            plugin.waitForStatusChange(client, "my_session", COMMITTING, COMMITTED, "", false);
         }
     }
 


### PR DESCRIPTION
**Context:** If bulk-import perform job is killed, then the entire execution will be stuck with `waitForStatusChange` due to unchanged bulk-import's status.

This PR adds the additional check to avoid that situation.