### PR TITLE
Skip job status side check if receiving exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = "com.treasuredata.embulk.plugins"
-version = "0.8.3-SNAPSHOT"
+version = "0.8.4-SNAPSHOT"
 description = "TreasureData output plugin is an Embulk plugin that loads records to Treasure Data read by any input plugins."
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/output/td/TdOutputPlugin.java
+++ b/src/main/java/org/embulk/output/td/TdOutputPlugin.java
@@ -945,20 +945,32 @@ public class TdOutputPlugin
     {
         TDBulkImportSession importSession;
         int count = 0;
+        boolean stopAskingJobStatus = false;
+
         while (true) {
             importSession = client.getBulkImportSession(sessionName);
 
-            // Check if the job has been killed or not, otherwise it will be stuck forever.
-            if (isCheckingJobStatus && count > 20) {
-                if (importSession.getJobId() != null) {
-                    TDJobSummary jobSummary = client.jobStatus(importSession.getJobId());
-                    if (jobSummary.getStatus() == TDJob.Status.KILLED) {
-                        throw new BulkImportPerformJobKilledException(jobSummary.getJobId());
+            // Check if the job has been killed or not, otherwise it will be stuck forever
+            if (!stopAskingJobStatus && isCheckingJobStatus) {
+                if (count > 20) {
+                    if (importSession.getJobId() != null) {
+                        try {
+                            TDJobSummary jobSummary = client.jobStatus(importSession.getJobId());
+                            if (jobSummary.getStatus() == TDJob.Status.KILLED) {
+                                throw new BulkImportPerformJobKilledException(jobSummary.getJobId());
+                            }
+                        } catch (RuntimeException e) {
+                            if (e instanceof BulkImportPerformJobKilledException) {
+                                throw e;
+                            }
+                            log.warn("Failed to check job status for bulk import session '{}', reason: '{}'. Skip it.", sessionName, e.getMessage());
+                            stopAskingJobStatus = true;
+                        }
                     }
+                    count = 0; // reset count after checking job status
                 }
-                count = 0; // reset count after checking job status
+                count++;
             }
-            count++;
 
             if (importSession.getStatus() == expecting) {
                 return importSession;


### PR DESCRIPTION
Follow-up: https://github.com/treasure-data/embulk-output-td/pull/133, because checking job status is a side check, it shouldn't break the primary flow if it receives an exception during checking.